### PR TITLE
fix: resolve table format issue in chapter4 Summary section

### DIFF
--- a/chapter4.ipynb
+++ b/chapter4.ipynb
@@ -462,7 +462,7 @@
     "| Vanilla call | $\\max(S_T - K, 0)$ | Yes |\n",
     "| Vanilla put | $\\max(K - S_T, 0)$ | Yes |\n",
     "| Digital call | $\\mathbf{1}_{S_T > K}$ | Yes |\n",
-    "| Straddle | $|S_T - K|$ | Yes (call + put) |\n",
+    "| Straddle | $\\left|S_T - K\\right|$ | Yes (call + put) |\n",
     "| Power option | $\\max(S_T^2/S_0 - K, 0)$ | Difficult |\n",
     "| Capped call | $\\min(\\max(S_T - K, 0), C)$ | Possible |\n",
     "\n",


### PR DESCRIPTION
The Straddle row in the markdown table used `$|S_T - K|$` which contained pipe characters that broke the Markdown table rendering. Replaced with `$\left|S_T - K\right|$`.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)