### PR TITLE
[C++] Add stochastic simulation library with Python bindings and unit tests

### DIFF
--- a/cc_src/CMakeLists.txt
+++ b/cc_src/CMakeLists.txt
@@ -1,7 +1,57 @@
-PROJECT(SimpleHeatPDESolver)
 cmake_minimum_required(VERSION 3.10)
+project(StochasticProcessLib)
 
-add_subdirectory(pybind11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-#pybind11_add_module(SimpleHeatPDESolver main.cc)
+# Prefer pip-installed pybind11 (Python 3.11 compatible) over the bundled submodule
+execute_process(
+    COMMAND python -m pybind11 --cmakedir
+    OUTPUT_VARIABLE PYBIND11_CMAKE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(PYBIND11_CMAKE_DIR)
+    list(APPEND CMAKE_PREFIX_PATH "${PYBIND11_CMAKE_DIR}")
+    find_package(pybind11 REQUIRED)
+else()
+    add_subdirectory(pybind11)
+endif()
+
+# -------------------------------------------------------
+# Original heat equation solver (chapter3)
+# -------------------------------------------------------
 pybind11_add_module(heat main.cc)
+
+# -------------------------------------------------------
+# Stochastic simulation library (static, no Python dep)
+# -------------------------------------------------------
+set(STOCHASTIC_SOURCES
+    stochastic/process.cpp
+    stochastic/payoff.cpp
+)
+
+add_library(stochastic_lib STATIC ${STOCHASTIC_SOURCES})
+target_include_directories(stochastic_lib PUBLIC stochastic)
+target_compile_options(stochastic_lib PRIVATE -Wall -Wextra -O2)
+set_property(TARGET stochastic_lib PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# -------------------------------------------------------
+# Python extension module: stochastic
+# -------------------------------------------------------
+pybind11_add_module(stochastic stochastic/bindings.cpp)
+target_link_libraries(stochastic PRIVATE stochastic_lib)
+target_include_directories(stochastic PRIVATE stochastic)
+
+# -------------------------------------------------------
+# C++ unit tests
+# -------------------------------------------------------
+add_executable(test_stochastic
+    stochastic/tests/test_stochastic.cpp
+    stochastic/process.cpp
+    stochastic/payoff.cpp
+)
+target_include_directories(test_stochastic PRIVATE stochastic stochastic/tests)
+target_compile_options(test_stochastic PRIVATE -Wall -Wextra -O2)
+
+enable_testing()
+add_test(NAME StochasticTests COMMAND test_stochastic)

--- a/cc_src/stochastic/bindings.cpp
+++ b/cc_src/stochastic/bindings.cpp
@@ -1,0 +1,170 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+#include "rng.h"
+#include "process.h"
+#include "payoff.h"
+#include "mc.h"
+
+namespace py = pybind11;
+
+// Helper: convert vector<vector<double>> to 2-D numpy array (n_paths x path_len)
+static py::array_t<double> to_numpy_2d(const std::vector<std::vector<double>>& paths) {
+    if (paths.empty()) return py::array_t<double>(std::vector<size_t>{0, 0});
+    size_t nrows = paths.size();
+    size_t ncols = paths[0].size();
+    py::array_t<double> arr({nrows, ncols});
+    auto buf = arr.mutable_unchecked<2>();
+    for (size_t i = 0; i < nrows; ++i)
+        for (size_t j = 0; j < ncols; ++j)
+            buf(i, j) = paths[i][j];
+    return arr;
+}
+
+PYBIND11_MODULE(stochastic, m) {
+    m.doc() = "Stochastic process simulation library for quantitative finance";
+
+    // --------------------------------------------------------
+    // MCResult
+    // --------------------------------------------------------
+    py::class_<MCResult>(m, "MCResult")
+        .def_readonly("price",     &MCResult::price)
+        .def_readonly("std_error", &MCResult::std_error)
+        .def_readonly("n_paths",   &MCResult::n_paths)
+        .def("__repr__", [](const MCResult& r) {
+            return "MCResult(price=" + std::to_string(r.price) +
+                   ", std_error=" + std::to_string(r.std_error) +
+                   ", n_paths=" + std::to_string(r.n_paths) + ")";
+        });
+
+    // --------------------------------------------------------
+    // RNG
+    // --------------------------------------------------------
+    py::class_<RNG>(m, "RNG")
+        .def(py::init<unsigned>(), py::arg("seed") = 42)
+        .def("seed",          &RNG::seed)
+        .def("normal",        py::overload_cast<>(&RNG::normal))
+        .def("normal",        py::overload_cast<double, double>(&RNG::normal),
+             py::arg("mean"), py::arg("stddev"))
+        .def("poisson",       &RNG::poisson,  py::arg("lambda_"))
+        .def("uniform",       &RNG::uniform)
+        .def("normal_vector", &RNG::normal_vector, py::arg("n"));
+
+    // --------------------------------------------------------
+    // WienerProcess
+    // --------------------------------------------------------
+    py::class_<WienerProcess>(m, "WienerProcess")
+        .def(py::init<>())
+        .def("simulate_terminal", &WienerProcess::simulate_terminal,
+             py::arg("T"), py::arg("rng"))
+        .def("simulate_path", [](const WienerProcess& self, double T, int n_steps, RNG& rng) {
+                return self.simulate_path(T, n_steps, rng);
+             }, py::arg("T"), py::arg("n_steps"), py::arg("rng"))
+        .def("simulate_paths", [](const WienerProcess& self, double T, int n_steps, int n_paths, RNG& rng) {
+                return to_numpy_2d(self.simulate_paths(T, n_steps, n_paths, rng));
+             }, py::arg("T"), py::arg("n_steps"), py::arg("n_paths"), py::arg("rng"));
+
+    // --------------------------------------------------------
+    // GBMProcess
+    // --------------------------------------------------------
+    py::class_<GBMProcess>(m, "GBMProcess")
+        .def(py::init<double, double, double>(),
+             py::arg("S0"), py::arg("r"), py::arg("sigma"))
+        .def("simulate_terminal", &GBMProcess::simulate_terminal,
+             py::arg("T"), py::arg("rng"))
+        .def("simulate_path", [](const GBMProcess& self, double T, int n_steps, RNG& rng) {
+                return self.simulate_path(T, n_steps, rng);
+             }, py::arg("T"), py::arg("n_steps"), py::arg("rng"))
+        .def("simulate_paths", [](const GBMProcess& self, double T, int n_steps, int n_paths, RNG& rng) {
+                return to_numpy_2d(self.simulate_paths(T, n_steps, n_paths, rng));
+             }, py::arg("T"), py::arg("n_steps"), py::arg("n_paths"), py::arg("rng"))
+        .def_property_readonly("S0",    &GBMProcess::get_S0)
+        .def_property_readonly("r",     &GBMProcess::r)
+        .def_property_readonly("sigma", &GBMProcess::get_sigma);
+
+    // --------------------------------------------------------
+    // MertonProcess
+    // --------------------------------------------------------
+    py::class_<MertonProcess>(m, "MertonProcess")
+        .def(py::init<double, double, double, double, double, double>(),
+             py::arg("S0"), py::arg("r"), py::arg("sigma"),
+             py::arg("lam"), py::arg("mu_J"), py::arg("sigma_J"))
+        .def("compensator",       &MertonProcess::compensator)
+        .def("simulate_terminal", &MertonProcess::simulate_terminal,
+             py::arg("T"), py::arg("rng"))
+        .def("simulate_path", [](const MertonProcess& self, double T, int n_steps, RNG& rng) {
+                return self.simulate_path(T, n_steps, rng);
+             }, py::arg("T"), py::arg("n_steps"), py::arg("rng"))
+        .def("simulate_paths", [](const MertonProcess& self, double T, int n_steps, int n_paths, RNG& rng) {
+                return to_numpy_2d(self.simulate_paths(T, n_steps, n_paths, rng));
+             }, py::arg("T"), py::arg("n_steps"), py::arg("n_paths"), py::arg("rng"))
+        .def_property_readonly("S0",      &MertonProcess::get_S0)
+        .def_property_readonly("r",       &MertonProcess::r)
+        .def_property_readonly("sigma",   &MertonProcess::get_sigma)
+        .def_property_readonly("lam",     &MertonProcess::get_lam)
+        .def_property_readonly("mu_J",    &MertonProcess::get_mu_J)
+        .def_property_readonly("sigma_J", &MertonProcess::get_sigma_J);
+
+    // --------------------------------------------------------
+    // Payoff classes
+    // --------------------------------------------------------
+    py::class_<Payoff>(m, "Payoff")
+        .def("evaluate", &Payoff::evaluate, py::arg("path"));
+
+    py::class_<EuropeanCall, Payoff>(m, "EuropeanCall")
+        .def(py::init<double>(), py::arg("K"));
+
+    py::class_<EuropeanPut, Payoff>(m, "EuropeanPut")
+        .def(py::init<double>(), py::arg("K"));
+
+    py::class_<DigitalCall, Payoff>(m, "DigitalCall")
+        .def(py::init<double>(), py::arg("K"));
+
+    py::class_<AsianCall, Payoff>(m, "AsianCall")
+        .def(py::init<double>(), py::arg("K"));
+
+    py::class_<AsianPut, Payoff>(m, "AsianPut")
+        .def(py::init<double>(), py::arg("K"));
+
+    py::class_<UpAndOutCall, Payoff>(m, "UpAndOutCall")
+        .def(py::init<double, double>(), py::arg("K"), py::arg("barrier"));
+
+    py::class_<DownAndOutPut, Payoff>(m, "DownAndOutPut")
+        .def(py::init<double, double>(), py::arg("K"), py::arg("barrier"));
+
+    py::class_<FloatingLookbackCall, Payoff>(m, "FloatingLookbackCall")
+        .def(py::init<>());
+
+    py::class_<FloatingLookbackPut, Payoff>(m, "FloatingLookbackPut")
+        .def(py::init<>());
+
+    py::class_<FixedLookbackCall, Payoff>(m, "FixedLookbackCall")
+        .def(py::init<double>(), py::arg("K"));
+
+    py::class_<FixedLookbackPut, Payoff>(m, "FixedLookbackPut")
+        .def(py::init<double>(), py::arg("K"));
+
+    // --------------------------------------------------------
+    // MC pricing functions
+    // --------------------------------------------------------
+    m.def("mc_price_gbm",
+        [](const GBMProcess& proc, const Payoff& payoff,
+           double T, int n_steps, int n_paths, unsigned seed) {
+            return mc_price(proc, payoff, T, n_steps, n_paths, seed);
+        },
+        py::arg("process"), py::arg("payoff"),
+        py::arg("T"), py::arg("n_steps"), py::arg("n_paths"),
+        py::arg("seed") = 42,
+        "Price an option on a GBM process via Monte Carlo.");
+
+    m.def("mc_price_merton",
+        [](const MertonProcess& proc, const Payoff& payoff,
+           double T, int n_steps, int n_paths, unsigned seed) {
+            return mc_price(proc, payoff, T, n_steps, n_paths, seed);
+        },
+        py::arg("process"), py::arg("payoff"),
+        py::arg("T"), py::arg("n_steps"), py::arg("n_paths"),
+        py::arg("seed") = 42,
+        "Price an option on a Merton jump-diffusion process via Monte Carlo.");
+}

--- a/cc_src/stochastic/mc.h
+++ b/cc_src/stochastic/mc.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "rng.h"
+#include "payoff.h"
+#include <cmath>
+#include <vector>
+
+/**
+ * Result of a Monte Carlo pricing run.
+ */
+struct MCResult {
+    double price;      // discounted expected payoff
+    double std_error;  // standard error of the estimate
+    int    n_paths;    // number of simulated paths
+};
+
+/**
+ * Monte Carlo pricer — works with any process type that provides:
+ *   - double r() const
+ *   - std::vector<double> simulate_path(double T, int n_steps, RNG&) const
+ *
+ * Template is header-only so it can be instantiated for any process.
+ *
+ * @param process   Process object (GBMProcess, MertonProcess, etc.)
+ * @param payoff    Payoff functor deriving from Payoff
+ * @param T         Maturity (years)
+ * @param n_steps   Time-steps per path (use 1 for European terminal-only)
+ * @param n_paths   Number of Monte Carlo paths
+ * @param seed      RNG seed for reproducibility
+ */
+template <typename Process>
+MCResult mc_price(const Process& process,
+                  const Payoff&  payoff,
+                  double T,
+                  int    n_steps,
+                  int    n_paths,
+                  unsigned seed = 42)
+{
+    RNG rng(seed);
+    double discount = std::exp(-process.r() * T);
+
+    double sum    = 0.0;
+    double sum_sq = 0.0;
+
+    for (int i = 0; i < n_paths; ++i) {
+        auto   path = process.simulate_path(T, n_steps, rng);
+        double pv   = discount * payoff.evaluate(path);
+        sum    += pv;
+        sum_sq += pv * pv;
+    }
+
+    double mean     = sum / n_paths;
+    double variance = (sum_sq / n_paths) - mean * mean;
+    double std_err  = std::sqrt(std::max(variance, 0.0) / n_paths);
+
+    return {mean, std_err, n_paths};
+}

--- a/cc_src/stochastic/payoff.cpp
+++ b/cc_src/stochastic/payoff.cpp
@@ -1,0 +1,64 @@
+#include "payoff.h"
+#include <cmath>
+
+// ---- European ----
+
+double EuropeanCall::evaluate(const std::vector<double>& path) const {
+    return std::max(path.back() - K_, 0.0);
+}
+
+double EuropeanPut::evaluate(const std::vector<double>& path) const {
+    return std::max(K_ - path.back(), 0.0);
+}
+
+double DigitalCall::evaluate(const std::vector<double>& path) const {
+    return path.back() > K_ ? 1.0 : 0.0;
+}
+
+// ---- Asian ----
+
+double AsianCall::evaluate(const std::vector<double>& path) const {
+    double avg = std::accumulate(path.begin(), path.end(), 0.0) / static_cast<double>(path.size());
+    return std::max(avg - K_, 0.0);
+}
+
+double AsianPut::evaluate(const std::vector<double>& path) const {
+    double avg = std::accumulate(path.begin(), path.end(), 0.0) / static_cast<double>(path.size());
+    return std::max(K_ - avg, 0.0);
+}
+
+// ---- Barrier ----
+
+double UpAndOutCall::evaluate(const std::vector<double>& path) const {
+    double max_price = *std::max_element(path.begin(), path.end());
+    if (max_price >= barrier_) return 0.0;
+    return std::max(path.back() - K_, 0.0);
+}
+
+double DownAndOutPut::evaluate(const std::vector<double>& path) const {
+    double min_price = *std::min_element(path.begin(), path.end());
+    if (min_price <= barrier_) return 0.0;
+    return std::max(K_ - path.back(), 0.0);
+}
+
+// ---- Lookback ----
+
+double FloatingLookbackCall::evaluate(const std::vector<double>& path) const {
+    double min_price = *std::min_element(path.begin(), path.end());
+    return path.back() - min_price;
+}
+
+double FloatingLookbackPut::evaluate(const std::vector<double>& path) const {
+    double max_price = *std::max_element(path.begin(), path.end());
+    return max_price - path.back();
+}
+
+double FixedLookbackCall::evaluate(const std::vector<double>& path) const {
+    double max_price = *std::max_element(path.begin(), path.end());
+    return std::max(max_price - K_, 0.0);
+}
+
+double FixedLookbackPut::evaluate(const std::vector<double>& path) const {
+    double min_price = *std::min_element(path.begin(), path.end());
+    return std::max(K_ - min_price, 0.0);
+}

--- a/cc_src/stochastic/payoff.h
+++ b/cc_src/stochastic/payoff.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <vector>
+#include <algorithm>
+#include <numeric>
+
+/**
+ * Abstract base for path-dependent payoffs.
+ * The path vector contains prices at each time step: [S(0), S(dt), ..., S(T)].
+ */
+struct Payoff {
+    virtual double evaluate(const std::vector<double>& path) const = 0;
+    virtual ~Payoff() = default;
+};
+
+// ============================================================
+// European / terminal payoffs
+// ============================================================
+
+class EuropeanCall : public Payoff {
+public:
+    explicit EuropeanCall(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};
+
+class EuropeanPut : public Payoff {
+public:
+    explicit EuropeanPut(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};
+
+// Pays $1 if S(T) > K, else 0
+class DigitalCall : public Payoff {
+public:
+    explicit DigitalCall(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};
+
+// ============================================================
+// Asian options (arithmetic average price)
+// ============================================================
+
+class AsianCall : public Payoff {
+public:
+    explicit AsianCall(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};
+
+class AsianPut : public Payoff {
+public:
+    explicit AsianPut(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};
+
+// ============================================================
+// Barrier options (continuous monitoring)
+// ============================================================
+
+// Knocked out if max(S) >= barrier
+class UpAndOutCall : public Payoff {
+public:
+    UpAndOutCall(double K, double barrier) : K_(K), barrier_(barrier) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_, barrier_;
+};
+
+// Knocked out if min(S) <= barrier
+class DownAndOutPut : public Payoff {
+public:
+    DownAndOutPut(double K, double barrier) : K_(K), barrier_(barrier) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_, barrier_;
+};
+
+// ============================================================
+// Lookback options
+// ============================================================
+
+// Floating lookback call: S(T) - min(S)
+class FloatingLookbackCall : public Payoff {
+public:
+    double evaluate(const std::vector<double>& path) const override;
+};
+
+// Floating lookback put: max(S) - S(T)
+class FloatingLookbackPut : public Payoff {
+public:
+    double evaluate(const std::vector<double>& path) const override;
+};
+
+// Fixed lookback call: max(max(S) - K, 0)
+class FixedLookbackCall : public Payoff {
+public:
+    explicit FixedLookbackCall(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};
+
+// Fixed lookback put: max(K - min(S), 0)
+class FixedLookbackPut : public Payoff {
+public:
+    explicit FixedLookbackPut(double K) : K_(K) {}
+    double evaluate(const std::vector<double>& path) const override;
+private:
+    double K_;
+};

--- a/cc_src/stochastic/process.cpp
+++ b/cc_src/stochastic/process.cpp
@@ -1,0 +1,120 @@
+#include "process.h"
+#include <cmath>
+#include <stdexcept>
+
+// ============================================================
+// WienerProcess
+// ============================================================
+
+double WienerProcess::simulate_terminal(double T, RNG& rng) const {
+    return std::sqrt(T) * rng.normal();
+}
+
+std::vector<double> WienerProcess::simulate_path(double T, int n_steps, RNG& rng) const {
+    if (n_steps <= 0) throw std::invalid_argument("n_steps must be positive");
+    double sqrt_dt = std::sqrt(T / n_steps);
+    std::vector<double> path(n_steps + 1);
+    path[0] = 0.0;
+    for (int i = 1; i <= n_steps; ++i)
+        path[i] = path[i - 1] + sqrt_dt * rng.normal();
+    return path;
+}
+
+std::vector<std::vector<double>> WienerProcess::simulate_paths(
+    double T, int n_steps, int n_paths, RNG& rng) const
+{
+    std::vector<std::vector<double>> paths(n_paths);
+    for (auto& p : paths)
+        p = simulate_path(T, n_steps, rng);
+    return paths;
+}
+
+// ============================================================
+// GBMProcess
+// ============================================================
+
+GBMProcess::GBMProcess(double S0, double r, double sigma)
+    : S0_(S0), r_(r), sigma_(sigma) {}
+
+double GBMProcess::simulate_terminal(double T, RNG& rng) const {
+    double drift     = (r_ - 0.5 * sigma_ * sigma_) * T;
+    double diffusion = sigma_ * std::sqrt(T) * rng.normal();
+    return S0_ * std::exp(drift + diffusion);
+}
+
+std::vector<double> GBMProcess::simulate_path(double T, int n_steps, RNG& rng) const {
+    if (n_steps <= 0) throw std::invalid_argument("n_steps must be positive");
+    double dt       = T / n_steps;
+    double drift    = (r_ - 0.5 * sigma_ * sigma_) * dt;
+    double sqrt_dt  = std::sqrt(dt);
+
+    std::vector<double> path(n_steps + 1);
+    path[0] = S0_;
+    for (int i = 1; i <= n_steps; ++i)
+        path[i] = path[i - 1] * std::exp(drift + sigma_ * sqrt_dt * rng.normal());
+    return path;
+}
+
+std::vector<std::vector<double>> GBMProcess::simulate_paths(
+    double T, int n_steps, int n_paths, RNG& rng) const
+{
+    std::vector<std::vector<double>> paths(n_paths);
+    for (auto& p : paths)
+        p = simulate_path(T, n_steps, rng);
+    return paths;
+}
+
+// ============================================================
+// MertonProcess
+// ============================================================
+
+MertonProcess::MertonProcess(double S0, double r, double sigma,
+                             double lam, double mu_J, double sigma_J)
+    : S0_(S0), r_(r), sigma_(sigma), lam_(lam), mu_J_(mu_J), sigma_J_(sigma_J) {}
+
+double MertonProcess::compensator() const {
+    return std::exp(mu_J_ + 0.5 * sigma_J_ * sigma_J_) - 1.0;
+}
+
+double MertonProcess::simulate_terminal(double T, RNG& rng) const {
+    double kbar      = compensator();
+    double drift     = (r_ - lam_ * kbar - 0.5 * sigma_ * sigma_) * T;
+    double diffusion = sigma_ * std::sqrt(T) * rng.normal();
+
+    // Draw total number of jumps over [0,T]
+    int n_jumps = rng.poisson(lam_ * T);
+    double jump_sum = 0.0;
+    for (int i = 0; i < n_jumps; ++i)
+        jump_sum += rng.normal(mu_J_, sigma_J_);
+
+    return S0_ * std::exp(drift + diffusion + jump_sum);
+}
+
+std::vector<double> MertonProcess::simulate_path(double T, int n_steps, RNG& rng) const {
+    if (n_steps <= 0) throw std::invalid_argument("n_steps must be positive");
+    double dt       = T / n_steps;
+    double kbar     = compensator();
+    double drift    = (r_ - lam_ * kbar - 0.5 * sigma_ * sigma_) * dt;
+    double sqrt_dt  = std::sqrt(dt);
+
+    std::vector<double> path(n_steps + 1);
+    path[0] = S0_;
+    for (int i = 1; i <= n_steps; ++i) {
+        double diffusion = sigma_ * sqrt_dt * rng.normal();
+        int n_jumps = rng.poisson(lam_ * dt);
+        double jump_sum = 0.0;
+        for (int j = 0; j < n_jumps; ++j)
+            jump_sum += rng.normal(mu_J_, sigma_J_);
+        path[i] = path[i - 1] * std::exp(drift + diffusion + jump_sum);
+    }
+    return path;
+}
+
+std::vector<std::vector<double>> MertonProcess::simulate_paths(
+    double T, int n_steps, int n_paths, RNG& rng) const
+{
+    std::vector<std::vector<double>> paths(n_paths);
+    for (auto& p : paths)
+        p = simulate_path(T, n_steps, rng);
+    return paths;
+}

--- a/cc_src/stochastic/process.h
+++ b/cc_src/stochastic/process.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "rng.h"
+#include <vector>
+
+/**
+ * Standard Wiener process (Brownian motion).
+ * Paths start at 0 and have increments ~ N(0, dt).
+ */
+class WienerProcess {
+public:
+    // Single terminal value B(T)
+    double simulate_terminal(double T, RNG& rng) const;
+
+    // Full path: returns (n_steps+1) values from t=0 to t=T
+    std::vector<double> simulate_path(double T, int n_steps, RNG& rng) const;
+
+    // n_paths independent paths, each of length (n_steps+1)
+    std::vector<std::vector<double>> simulate_paths(double T, int n_steps, int n_paths, RNG& rng) const;
+
+    // Required by mc_price template; Wiener process has r=0
+    double r() const { return 0.0; }
+};
+
+/**
+ * Geometric Brownian Motion under the risk-neutral measure:
+ *   dS = r*S*dt + sigma*S*dW
+ *
+ * Exact discretization (no Euler error):
+ *   S(t+dt) = S(t) * exp((r - sigma^2/2)*dt + sigma*sqrt(dt)*Z)
+ */
+class GBMProcess {
+public:
+    GBMProcess(double S0, double r, double sigma);
+
+    // Terminal value S(T)
+    double simulate_terminal(double T, RNG& rng) const;
+
+    // Full path: (n_steps+1) prices from t=0 to t=T
+    std::vector<double> simulate_path(double T, int n_steps, RNG& rng) const;
+
+    // n_paths independent paths
+    std::vector<std::vector<double>> simulate_paths(double T, int n_steps, int n_paths, RNG& rng) const;
+
+    double get_S0()    const { return S0_;    }
+    double r()         const { return r_;     }
+    double get_sigma() const { return sigma_; }
+
+private:
+    double S0_, r_, sigma_;
+};
+
+/**
+ * Merton (1976) jump-diffusion model under the risk-neutral measure:
+ *   dS/S = (r - lambda*kbar)*dt + sigma*dW + (e^J - 1)*dN
+ *
+ * where:
+ *   N ~ Poisson(lambda) is the jump count process
+ *   J ~ N(mu_J, sigma_J^2) is the log-jump size
+ *   kbar = E[e^J - 1] = exp(mu_J + 0.5*sigma_J^2) - 1  (compensator)
+ */
+class MertonProcess {
+public:
+    MertonProcess(double S0, double r, double sigma,
+                  double lam, double mu_J, double sigma_J);
+
+    // kbar = exp(mu_J + 0.5*sigma_J^2) - 1
+    double compensator() const;
+
+    // Terminal value via exact simulation (no time-stepping error)
+    double simulate_terminal(double T, RNG& rng) const;
+
+    // Full path via Euler steps with Poisson jumps at each step
+    std::vector<double> simulate_path(double T, int n_steps, RNG& rng) const;
+
+    // n_paths independent paths
+    std::vector<std::vector<double>> simulate_paths(double T, int n_steps, int n_paths, RNG& rng) const;
+
+    double get_S0()      const { return S0_;      }
+    double r()           const { return r_;       }
+    double get_sigma()   const { return sigma_;   }
+    double get_lam()     const { return lam_;     }
+    double get_mu_J()    const { return mu_J_;    }
+    double get_sigma_J() const { return sigma_J_; }
+
+private:
+    double S0_, r_, sigma_, lam_, mu_J_, sigma_J_;
+};

--- a/cc_src/stochastic/rng.h
+++ b/cc_src/stochastic/rng.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <random>
+#include <vector>
+#include <cmath>
+#include <cstdint>
+
+/**
+ * Random Number Generator wrapper around std::mt19937_64.
+ * Provides convenience methods for distributions used in stochastic simulation.
+ */
+class RNG {
+public:
+    explicit RNG(unsigned seed = std::random_device{}())
+        : engine_(seed), normal_dist_(0.0, 1.0) {}
+
+    void seed(unsigned s) {
+        engine_.seed(s);
+        normal_dist_.reset();
+    }
+
+    // Standard normal N(0,1)
+    double normal() { return normal_dist_(engine_); }
+
+    // General normal N(mean, stddev^2)
+    double normal(double mean, double stddev) {
+        return mean + stddev * normal_dist_(engine_);
+    }
+
+    // Poisson(lambda) — returns number of events
+    int poisson(double lambda) {
+        std::poisson_distribution<int> dist(lambda);
+        return dist(engine_);
+    }
+
+    // Uniform [0, 1)
+    double uniform() {
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        return dist(engine_);
+    }
+
+    // Vector of n iid standard normals
+    std::vector<double> normal_vector(size_t n) {
+        std::vector<double> v(n);
+        for (auto& x : v) x = normal_dist_(engine_);
+        return v;
+    }
+
+private:
+    std::mt19937_64 engine_;
+    std::normal_distribution<double> normal_dist_;
+};

--- a/cc_src/stochastic/tests/test_runner.h
+++ b/cc_src/stochastic/tests/test_runner.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <cstdlib>
+#include <cmath>
+
+// Minimal test framework — no external dependencies
+
+static int g_tests_run    = 0;
+static int g_tests_passed = 0;
+static int g_tests_failed = 0;
+
+#define TEST(name) \
+    static void name(); \
+    struct name##_reg { name##_reg() { \
+        ++g_tests_run; \
+        std::cout << "  [ RUN ] " #name << std::endl; \
+        try { name(); ++g_tests_passed; std::cout << "  [PASS] " #name << std::endl; } \
+        catch (const std::exception& e) { ++g_tests_failed; std::cout << "  [FAIL] " #name ": " << e.what() << std::endl; } \
+    } } name##_instance; \
+    static void name()
+
+#define EXPECT_NEAR(a, b, tol) \
+    do { \
+        double _a = (a), _b = (b), _t = (tol); \
+        if (std::abs(_a - _b) > _t) { \
+            throw std::runtime_error( \
+                std::string("EXPECT_NEAR failed: |") + std::to_string(_a) + " - " + std::to_string(_b) + \
+                "| = " + std::to_string(std::abs(_a - _b)) + " > " + std::to_string(_t)); \
+        } \
+    } while(0)
+
+#define EXPECT_TRUE(cond) \
+    do { \
+        if (!(cond)) throw std::runtime_error("EXPECT_TRUE failed: " #cond); \
+    } while(0)
+
+#define EXPECT_LT(a, b) \
+    do { \
+        if (!((a) < (b))) throw std::runtime_error( \
+            std::string("EXPECT_LT failed: ") + std::to_string(a) + " >= " + std::to_string(b)); \
+    } while(0)
+
+#define EXPECT_GT(a, b) \
+    do { \
+        if (!((a) > (b))) throw std::runtime_error( \
+            std::string("EXPECT_GT failed: ") + std::to_string(a) + " <= " + std::to_string(b)); \
+    } while(0)
+
+inline int test_summary() {
+    std::cout << "\n============================\n";
+    std::cout << "Tests run:    " << g_tests_run    << "\n";
+    std::cout << "Tests passed: " << g_tests_passed << "\n";
+    std::cout << "Tests failed: " << g_tests_failed << "\n";
+    std::cout << "============================\n";
+    return g_tests_failed > 0 ? 1 : 0;
+}

--- a/cc_src/stochastic/tests/test_stochastic.cpp
+++ b/cc_src/stochastic/tests/test_stochastic.cpp
@@ -1,0 +1,332 @@
+#include "test_runner.h"
+
+#include "../rng.h"
+#include "../process.h"
+#include "../payoff.h"
+#include "../mc.h"
+
+#include <cmath>
+#include <vector>
+#include <numeric>
+
+// ============================================================
+// RNG tests
+// ============================================================
+
+TEST(rng_normal_mean_variance) {
+    // N samples of N(0,1); check mean ~0, var ~1 to 2 decimal places
+    RNG rng(123);
+    const int N = 100000;
+    double sum = 0, sum_sq = 0;
+    for (int i = 0; i < N; ++i) {
+        double x = rng.normal();
+        sum += x;
+        sum_sq += x * x;
+    }
+    double mean = sum / N;
+    double var  = sum_sq / N - mean * mean;
+    EXPECT_NEAR(mean, 0.0, 0.01);
+    EXPECT_NEAR(var,  1.0, 0.02);
+}
+
+TEST(rng_normal_shifted) {
+    RNG rng(42);
+    const int N = 50000;
+    double sum = 0;
+    for (int i = 0; i < N; ++i)
+        sum += rng.normal(5.0, 2.0);
+    EXPECT_NEAR(sum / N, 5.0, 0.05);
+}
+
+TEST(rng_poisson_mean) {
+    // Poisson(lam): sample mean should be ~lam
+    RNG rng(7);
+    const double lam = 3.0;
+    const int N = 100000;
+    double sum = 0;
+    for (int i = 0; i < N; ++i)
+        sum += rng.poisson(lam);
+    EXPECT_NEAR(sum / N, lam, 0.05);
+}
+
+TEST(rng_seeded_reproducibility) {
+    RNG a(999), b(999);
+    for (int i = 0; i < 10; ++i)
+        EXPECT_NEAR(a.normal(), b.normal(), 1e-15);
+}
+
+// ============================================================
+// WienerProcess tests
+// ============================================================
+
+TEST(wiener_terminal_distribution) {
+    // B(T) ~ N(0, T); check variance ~T using many samples
+    WienerProcess W;
+    RNG rng(1);
+    const int N = 100000;
+    const double T = 2.0;
+    double sum_sq = 0;
+    for (int i = 0; i < N; ++i) {
+        double b = W.simulate_terminal(T, rng);
+        sum_sq += b * b;
+    }
+    // E[B(T)^2] = T
+    EXPECT_NEAR(sum_sq / N, T, 0.05);
+}
+
+TEST(wiener_path_starts_at_zero) {
+    WienerProcess W;
+    RNG rng(2);
+    auto path = W.simulate_path(1.0, 100, rng);
+    EXPECT_NEAR(path[0], 0.0, 1e-15);
+    EXPECT_TRUE(path.size() == 101);
+}
+
+TEST(wiener_ito_isometry_chapter1) {
+    // Verify Ito isometry: Var[int_0^1 s^2 dB_s] = int_0^1 s^4 ds = 0.2
+    // Simulation: sum f(s_i) * dB_i  where f(s) = s^2
+    RNG rng(42);
+    const int ndiv = 1000;
+    const double T = 1.0;
+    const int n_trials = 10000;
+    double dt = T / ndiv;
+    double sqrt_dt = std::sqrt(dt);
+
+    double sum_sq = 0;
+    for (int trial = 0; trial < n_trials; ++trial) {
+        double integral = 0;
+        for (int i = 0; i < ndiv; ++i) {
+            double s = i * dt;          // left endpoint
+            double dB = sqrt_dt * rng.normal();
+            integral += s * s * dB;
+        }
+        sum_sq += integral * integral;
+    }
+    double var = sum_sq / n_trials;
+    // Theoretical variance = int_0^1 s^4 ds = 0.2
+    EXPECT_NEAR(var, 0.2, 0.01);
+}
+
+// ============================================================
+// GBMProcess tests
+// ============================================================
+
+TEST(gbm_terminal_lognormal) {
+    // Under risk-neutral: log(S_T/S0) ~ N((r - sigma^2/2)*T, sigma^2*T)
+    GBMProcess gbm(100.0, 0.05, 0.2);
+    RNG rng(10);
+    const int N = 100000;
+    const double T = 1.0;
+
+    double sum_log = 0, sum_log_sq = 0;
+    for (int i = 0; i < N; ++i) {
+        double log_return = std::log(gbm.simulate_terminal(T, rng) / 100.0);
+        sum_log    += log_return;
+        sum_log_sq += log_return * log_return;
+    }
+    double mean_log = sum_log / N;
+    double var_log  = sum_log_sq / N - mean_log * mean_log;
+
+    double expected_mean = (0.05 - 0.5 * 0.04) * T;   // (r - sigma^2/2)*T
+    double expected_var  = 0.04 * T;                   // sigma^2 * T
+
+    EXPECT_NEAR(mean_log, expected_mean, 0.01);
+    EXPECT_NEAR(var_log,  expected_var,  0.01);
+}
+
+TEST(gbm_path_length) {
+    GBMProcess gbm(100.0, 0.05, 0.2);
+    RNG rng(11);
+    auto path = gbm.simulate_path(1.0, 252, rng);
+    EXPECT_TRUE(path.size() == 253);
+    EXPECT_NEAR(path[0], 100.0, 1e-15);
+}
+
+TEST(gbm_paths_shape) {
+    GBMProcess gbm(100.0, 0.05, 0.2);
+    RNG rng(12);
+    auto paths = gbm.simulate_paths(1.0, 50, 200, rng);
+    EXPECT_TRUE(paths.size() == 200);
+    for (const auto& p : paths) EXPECT_TRUE(p.size() == 51);
+}
+
+// ============================================================
+// MertonProcess tests
+// ============================================================
+
+TEST(merton_compensator) {
+    // kbar = exp(mu_J + 0.5*sigma_J^2) - 1
+    MertonProcess m(100, 0.05, 0.15, 3.0, -0.05, 0.1);
+    double expected = std::exp(-0.05 + 0.5 * 0.01) - 1.0;
+    EXPECT_NEAR(m.compensator(), expected, 1e-12);
+}
+
+TEST(merton_terminal_positive) {
+    MertonProcess m(100, 0.05, 0.15, 3.0, -0.05, 0.1);
+    RNG rng(13);
+    for (int i = 0; i < 1000; ++i)
+        EXPECT_GT(m.simulate_terminal(1.0, rng), 0.0);
+}
+
+TEST(merton_paths_shape) {
+    MertonProcess m(100, 0.05, 0.15, 3.0, -0.05, 0.1);
+    RNG rng(14);
+    auto paths = m.simulate_paths(1.0, 50, 100, rng);
+    EXPECT_TRUE(paths.size() == 100);
+    for (const auto& p : paths) EXPECT_TRUE(p.size() == 51);
+}
+
+// ============================================================
+// Payoff tests
+// ============================================================
+
+TEST(european_call_payoff) {
+    EuropeanCall call(100.0);
+    EXPECT_NEAR(call.evaluate({90.0}),  0.0,  1e-12);
+    EXPECT_NEAR(call.evaluate({110.0}), 10.0, 1e-12);
+    EXPECT_NEAR(call.evaluate({100.0}), 0.0,  1e-12);
+}
+
+TEST(european_put_payoff) {
+    EuropeanPut put(100.0);
+    EXPECT_NEAR(put.evaluate({90.0}),  10.0, 1e-12);
+    EXPECT_NEAR(put.evaluate({110.0}),  0.0, 1e-12);
+}
+
+TEST(digital_call_payoff) {
+    DigitalCall dc(100.0);
+    EXPECT_NEAR(dc.evaluate({99.0}),  0.0, 1e-12);
+    EXPECT_NEAR(dc.evaluate({101.0}), 1.0, 1e-12);
+}
+
+TEST(asian_call_payoff) {
+    // avg = (80 + 90 + 100 + 110 + 120) / 5 = 100; payoff = max(100-100,0)=0
+    AsianCall ac(100.0);
+    std::vector<double> path = {80, 90, 100, 110, 120};
+    EXPECT_NEAR(ac.evaluate(path), 0.0, 1e-12);
+
+    // avg = (90+110+130)/3 = 110; payoff = 10
+    std::vector<double> path2 = {90, 110, 130};
+    EXPECT_NEAR(ac.evaluate(path2), 10.0, 1e-12);
+}
+
+TEST(up_and_out_call) {
+    UpAndOutCall uoc(100.0, 130.0);
+    // Barrier NOT hit, S_T = 120: payoff = 20
+    std::vector<double> path1 = {100, 110, 120};
+    EXPECT_NEAR(uoc.evaluate(path1), 20.0, 1e-12);
+    // Barrier hit (130): payoff = 0
+    std::vector<double> path2 = {100, 130, 120};
+    EXPECT_NEAR(uoc.evaluate(path2), 0.0, 1e-12);
+}
+
+TEST(down_and_out_put) {
+    DownAndOutPut dop(100.0, 80.0);
+    // Barrier NOT hit, S_T = 90: payoff = 10
+    std::vector<double> path1 = {100, 95, 90};
+    EXPECT_NEAR(dop.evaluate(path1), 10.0, 1e-12);
+    // Barrier hit: payoff = 0
+    std::vector<double> path2 = {100, 80, 90};
+    EXPECT_NEAR(dop.evaluate(path2), 0.0, 1e-12);
+}
+
+TEST(floating_lookback_call) {
+    FloatingLookbackCall flc;
+    // S_T - min(S) = 120 - 80 = 40
+    std::vector<double> path = {100, 80, 90, 120};
+    EXPECT_NEAR(flc.evaluate(path), 40.0, 1e-12);
+}
+
+TEST(floating_lookback_put) {
+    FloatingLookbackPut flp;
+    // max(S) - S_T = 130 - 90 = 40
+    std::vector<double> path = {100, 130, 110, 90};
+    EXPECT_NEAR(flp.evaluate(path), 40.0, 1e-12);
+}
+
+// ============================================================
+// Monte Carlo pricing tests
+// ============================================================
+
+TEST(mc_european_call_bs_benchmark) {
+    // Black-Scholes call: S=K=100, r=0.05, sigma=0.2, T=1
+    // BS price = 10.4506
+    GBMProcess gbm(100.0, 0.05, 0.2);
+    EuropeanCall call(100.0);
+    auto result = mc_price(gbm, call, 1.0, 1, 500000, 42);
+
+    EXPECT_NEAR(result.price, 10.4506, 0.15);   // within ~1.5% of BS
+    EXPECT_GT(result.std_error, 0.0);
+    EXPECT_TRUE(result.n_paths == 500000);
+}
+
+TEST(mc_put_call_parity) {
+    // C - P = S*exp(0) - K*exp(-rT) (when S=K, r>0: C > P)
+    GBMProcess gbm(100.0, 0.05, 0.2);
+    EuropeanCall call(100.0);
+    EuropeanPut  put(100.0);
+    auto rc = mc_price(gbm, call, 1.0, 1, 500000, 42);
+    auto rp = mc_price(gbm, put,  1.0, 1, 500000, 42);
+
+    // Put-call parity: C - P = S0 - K*exp(-r*T) = 100 - 100*exp(-0.05) ~= 4.877
+    double parity_theoretical = 100.0 - 100.0 * std::exp(-0.05);
+    EXPECT_NEAR(rc.price - rp.price, parity_theoretical, 0.15);
+}
+
+TEST(mc_asian_call_cheaper_than_european) {
+    // Asian options are always <= corresponding European option
+    GBMProcess   gbm(100.0, 0.05, 0.2);
+    EuropeanCall euro(100.0);
+    AsianCall    asian(100.0);
+    auto re = mc_price(gbm, euro,  1.0, 252, 200000, 42);
+    auto ra = mc_price(gbm, asian, 1.0, 252, 200000, 42);
+    EXPECT_LT(ra.price, re.price);
+}
+
+TEST(mc_barrier_call_cheaper_than_european) {
+    GBMProcess  gbm(100.0, 0.05, 0.2);
+    EuropeanCall euro(100.0);
+    UpAndOutCall barrier(100.0, 130.0);
+    auto re = mc_price(gbm, euro,    1.0, 252, 200000, 42);
+    auto rb = mc_price(gbm, barrier, 1.0, 252, 200000, 42);
+    EXPECT_LT(rb.price, re.price);
+}
+
+TEST(mc_lookback_call_pricier_than_european) {
+    GBMProcess        gbm(100.0, 0.05, 0.2);
+    EuropeanCall      euro(100.0);
+    FloatingLookbackCall lookback;
+    auto re = mc_price(gbm, euro,     1.0, 252, 200000, 42);
+    auto rl = mc_price(gbm, lookback, 1.0, 252, 200000, 42);
+    EXPECT_GT(rl.price, re.price);
+}
+
+TEST(mc_merton_call_pricier_than_gbm_call) {
+    // Merton model with crash-like jumps: overall option prices differ
+    // With lam=3, mu_J=-0.05: higher risk -> higher puts, modified calls
+    GBMProcess    gbm(100.0, 0.05, 0.15);
+    MertonProcess merton(100.0, 0.05, 0.15, 3.0, -0.05, 0.1);
+    EuropeanCall  call(100.0);
+
+    auto rg = mc_price(gbm,    call, 1.0, 1, 300000, 42);
+    auto rm = mc_price(merton, call, 1.0, 1, 300000, 42);
+
+    // Merton call price should differ from pure GBM (jumps add risk)
+    // With negative mu_J the Merton call should be higher than lower-vol GBM
+    EXPECT_GT(rm.price, rg.price);
+}
+
+TEST(mc_merton_terminal_vs_path) {
+    // Terminal simulation (n_steps=1) and full path (n_steps=252) should be close
+    MertonProcess merton(100.0, 0.05, 0.15, 3.0, -0.05, 0.1);
+    EuropeanCall call(100.0);
+    auto r1   = mc_price(merton, call, 1.0,   1, 300000, 42);
+    auto r252 = mc_price(merton, call, 1.0, 252, 300000, 42);
+    EXPECT_NEAR(r1.price, r252.price, 0.3);
+}
+
+// ============================================================
+int main() {
+    std::cout << "Running stochastic simulation library tests\n\n";
+    return test_summary();
+}


### PR DESCRIPTION
Implements a C++ numerical simulation library in cc_src/stochastic/ abstracting the Monte Carlo patterns from the Jupyter notebooks (chapters 1-7). Includes WienerProcess, GBMProcess, MertonProcess, all exotic payoff types, a template MC engine, pybind11 Python bindings, and 28 unit tests.

Closes #6

Generated with [Claude Code](https://claude.ai/code)